### PR TITLE
Introduce Message Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This package makes it easy to send notifications using [MobilyWs](https://www.mo
 	- [Create Notification](#create-notification)
 	- [Routing SMS Notifications](#routing-sms-notifications)
 	- [Sending SMS](#sending-sms)
+	- [Scheduled SMS](#scheduled-sms)
 	- [Available Message methods](#available-message-methods)
 - [TODO](#todo)
 - [Changelog](#changelog)
@@ -149,6 +150,24 @@ use App\Notifications\SmsNewUser;
 
 $user->notify(new SmsNewUser());
 ```
+
+### Scheduled SMS
+[MobilyWs](https://www.mobily.ws) api allows for sending scheduled message which will be sent on the defined date/time.
+
+> Please note that if you define time in the past, the message will be sent immediately by mobily.ws. 
+This library will not check if the defined time is in the future.
+
+You can define the time on which the message should be sent by mobily.ws by calling `time` method on the MobilyWsMessage instance.
+```php
+    public function toMobilyWs($notifiable)
+    {
+        return (new MobilyWsMessage)
+            ->text("Message text")
+            ->time(Carbon::parse("+1 week);
+    }
+```
+The time method accepts either a DateTime object or a timestamp.
+
 ### Available Message methods
 In your notification, you must define a method `toMobilyWs` which will receive the notifiable entity (e.g User model) and an instance of `MobilyWsMessage`. 
 
@@ -179,16 +198,19 @@ or set the text message using the `msg()` method:
 ```
 Method `toMobilyWs` will receive an instance of `MobilyWsMessage` as the 2nd argument.
 #### list of available methods :
-> Coming soon.
+`text()` To add the content of the text message
+'time()' To set time of the scheduled sms.
 
 ## TODO
 - [ ] Validate mobile numbers
 - [ ] Validate text messages type and length
-- [ ] Verify method `toMobilyWs` existence and config file.
-- [ ] Add the option to send Scheduled SMS
-- [ ] Add the the reset of params (MsgID, msgKey, deleteKey, timeSend, dateSend)
+- [ ] Validate given time is in the future.
+- [x] Verify method `toMobilyWs` existence and config file.
+- [x] Add the option to send Scheduled SMS
+- [ ] Add the the rest of params (MsgID, msgKey, deleteKey, ~~timeSend~~, ~~dateSend~~)
 - [ ] Translate mobily.ws error messages
 - [ ] Create artisan command to made mobily.ws notifications
+- [ ] Add list of fired event to the documentation.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/alhoqbani/laravel-mobily-ws-notification.svg?style=flat-square)](https://packagist.org/packages/alhoqbani/laravel-mobily-ws-notification)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/alhoqbani/laravel-mobily-ws-notification/master.svg?style=flat-square)](https://travis-ci.org/alhoqbani/laravel-mobily-ws-notification)
-[![StyleCI](https://styleci.io/repos/100258454/shield)](https://styleci.io/repos/100258454)
-[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
-[![Quality Score](https://img.shields.io/scrutinizer/g/alhoqbani/laravel-mobily-ws-notification.svg?style=flat-square)](https://scrutinizer-ci.com/g/alhoqbani/laravel-mobily-ws-notification)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/alhoqbani/laravel-mobily-ws-notification/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/alhoqbani/laravel-mobily-ws-notification/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/alhoqbani/laravel-mobily-ws-notification.svg?style=flat-square)](https://packagist.org/packages/alhoqbani/laravel-mobily-ws-notification)
 
@@ -15,8 +12,13 @@ This package makes it easy to send notifications using [MobilyWs](https://www.mo
 ## Contents
 
 - [Installation](#installation)
-	- [Setting up the MobilyWs service](#setting-up-the-MobilyWs-service)
+	- [Package Installation](#package-installation)
+	- [Set up mobily.ws account](#set-up-mobily.ws-account)
 - [Usage](#usage)
+	- [Credentials](#credentials)
+	- [Create Notification](#create-notification)
+	- [Routing SMS Notifications](#routing-sms-notifications)
+	- [Sending SMS](#sending-sms)
 	- [Available Message methods](#available-message-methods)
 - [TODO](#todo)
 - [Changelog](#changelog)
@@ -27,11 +29,15 @@ This package makes it easy to send notifications using [MobilyWs](https://www.mo
 
 
 ## Installation
-Install using composer:
+
+### Package Installation
+
+Install the package using composer:
 ```bash
 composer require alhoqbani/laravel-mobily-ws-notification
 ```
-Add service provider to your array of providers in `config/app.php`
+Add service provider to your array of providers in `config/app.php` 
+> You don't need to do this step for laravel 5.5+
 ```php
         NotificationChannels\MobilyWs\MobilyWsServiceProvider::class,
 ```
@@ -39,35 +45,43 @@ Publish the configuration file:
 ```bash
 php artisan vendor:publish --provider="NotificationChannels\MobilyWs\MobilyWsServiceProvider"
 ```
-### Setting up the Mobily.ws account
 
+### Set up mobily.ws account
 You must have an account with [MobilyWs](https://www.mobily.ws)  to be able to use this package.
 
 > This package has no affiliation with mobily.ws whatsoever. 
 
-## Usage
-### Add your mobily.ws credentials to your `.env` file.
-```php
-MOBILY_WS_MOBILE=
+#### Credentials.
+You must add mobily.ws credentials to your `.env` file.
+
+```
+// Mobile number and password used for log in.
+MOBILY_WS_MOBILE= 
 MOBILY_WS_PASSWORD=
-// Name/Number of Sender must be approved by mobily.ws for GCC
+// name/number of the sender which must be approved by mobily.ws for GCC
 MOBILY_WS_SENDER=
 ```
 
-### Make a new notification class using laravel artisan:
+## Usage
+
+### Create new notification:
+Make a new notification class using laravel artisan
 ```bash
 php artisan make:notification SmsNewUser
 ``` 
-### Configure the notification class to use MobilyWsChannel:
+Configure the notification class to use MobilyWsChannel:
 
-The `toMobilyWs` method should return a string of the text message to be sent.
+The `toMobilyWs` method should return a string of the text message to be sent or an instance of `MobilyWsMessage`.
+
+See [Available Message methods](#available-message-methods) for more details.
 ```php
 <?php
 
 namespace App\Notifications;
 
-use NotificationChannels\MobilyWs\MobilyWsChannel;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\MobilyWs\MobilyWsChannel;
+use NotificationChannels\MobilyWs\MobilyWsMessage;
 
 class SmsNewUser extends Notification
 {
@@ -86,7 +100,7 @@ class SmsNewUser extends Notification
      * Get the text message of the SMS.
      *
      * @param  mixed  $notifiable
-     * @return string 
+     * @return string|MobilyWsMessage 
      */
     public function toMobilyWs($notifiable)
     {
@@ -123,6 +137,7 @@ If you would like to customize the phone number the notification is delivered to
         }
     }
 ```
+`routeNotificationForMobilyWs` should return a mobile number to which the SMS message will be sent.
 
 Please note that the mobile number must start with the country code without leading zeros.
 
@@ -134,6 +149,37 @@ use App\Notifications\SmsNewUser;
 
 $user->notify(new SmsNewUser());
 ```
+### Available Message methods
+In your notification, you must define a method `toMobilyWs` which will receive the notifiable entity (e.g User model) and an instance of `MobilyWsMessage`. 
+
+This method should return the text of the message to be sent as an SMS to mobily.ws or an instance of `MobilyWsMessage`. 
+
+```php
+    /**
+     * Get the text message of the SMS.
+     *
+     * @param  mixed  $notifiable
+     * @return string|MobilyWsMessage 
+     */
+    public function toMobilyWs($notifiable)
+    {
+        return MobilyWsMessage::create("Text message");
+    }
+```
+You can also pass the message to `MobilyWsMessage` constructor:
+
+`return new MobilyWsMessage("Text message");`
+
+or set the text message using the `msg()` method:
+```php
+    public function toMobilyWs($notifiable, MobilyWsMessage $msg)
+    {
+        return $msg->text($this->message);
+    }
+```
+Method `toMobilyWs` will receive an instance of `MobilyWsMessage` as the 2nd argument.
+#### list of available methods :
+> Coming soon.
 
 ## TODO
 - [ ] Validate mobile numbers

--- a/src/MobilyWsApi.php
+++ b/src/MobilyWsApi.php
@@ -54,6 +54,8 @@ class MobilyWsApi
         $params = [
             'msg' => $message->text,
             'numbers' => $number,
+            'dateSend' => $message->dateSend(),
+            'timeSend' => $message->timeSend(),
         ];
         
         $payload = $this->preparePayload($params);
@@ -97,17 +99,13 @@ class MobilyWsApi
      */
     protected function preparePayload($params)
     {
-        $form = [
+        $form = array_merge([
             'mobile' => $this->config->mobile,
             'password' => $this->config->password,
             'applicationType' => $this->config->applicationType,
             'lang' => $this->config->lang,
             'sender' => $this->config->sender,
-            'msg' => $params['msg'],
-            'numbers' => $params['numbers'],
-            // For development to avoid charges
-            'dateSend' => \Carbon\Carbon::parse('+1 month')->format('m/d/Y'),
-        ];
+        ], $params);
 
         return array_merge(
             ['form_params' => $form],

--- a/src/MobilyWsApi.php
+++ b/src/MobilyWsApi.php
@@ -52,7 +52,7 @@ class MobilyWsApi
     public function sendMessage(MobilyWsMessage $message, $number)
     {
         $params = [
-            'msg' => $message->msg,
+            'msg' => $message->text,
             'numbers' => $number,
         ];
         

--- a/src/MobilyWsApi.php
+++ b/src/MobilyWsApi.php
@@ -106,7 +106,7 @@ class MobilyWsApi
             'msg' => $params['msg'],
             'numbers' => $params['numbers'],
             // For development to avoid charges
-//            'dateSend' => \Carbon\Carbon::parse('+1 month')->format('m/d/Y'),
+            'dateSend' => \Carbon\Carbon::parse('+1 month')->format('m/d/Y'),
         ];
 
         return array_merge(

--- a/src/MobilyWsApi.php
+++ b/src/MobilyWsApi.php
@@ -40,6 +40,27 @@ class MobilyWsApi
     }
     
     /**
+     * Send request with MobilyWsMessage instance
+     *
+     * @param MobilyWsMessage $message
+     *
+     * @param                 $number
+     *
+     * @return array
+     * @internal param $params
+     */
+    public function sendMessage(MobilyWsMessage $message, $number)
+    {
+        $params = [
+            'msg' => $message->msg,
+            'numbers' => $number,
+        ];
+        
+        $payload = $this->preparePayload($params);
+        return $this->send($payload);
+    }
+    
+    /**
      * Send request to mobily.ws
      *
      * @param array $payload

--- a/src/MobilyWsApi.php
+++ b/src/MobilyWsApi.php
@@ -25,19 +25,33 @@ class MobilyWsApi
         $this->http = $http;
         $this->config = $config;
     }
-
+    
     /**
-     * @param array $params
+     * Send request with string message
+     *
+     * @param $params
      *
      * @return array
-     *
-     * @throws CouldNotSendNotification
      */
-    public function send(array $params)
+    public function sendString($params)
+    {
+        $payload = $this->preparePayload($params);
+        return $this->send($payload);
+    }
+    
+    /**
+     * Send request to mobily.ws
+     *
+     * @param array $payload
+     *
+     * @return array
+     * @throws \NotificationChannels\MobilyWs\Exceptions\CouldNotSendNotification
+     * @internal param array $params
+     *
+     */
+    public function send(array $payload)
     {
         $endpoint = 'msgSend.php';
-        $payload = $this->preparePayload($params);
-
         try {
             $response = $this->http->post($endpoint, $payload);
 

--- a/src/MobilyWsChannel.php
+++ b/src/MobilyWsChannel.php
@@ -42,7 +42,7 @@ class MobilyWsChannel
         if (!method_exists($notification, 'toMobilyWs')) {
             throw CouldNotSendNotification::withErrorMessage('MobilyWs notifications must have toMobilyWs method');
         }
-        $message = $notification->toMobilyWs($notifiable);
+        $message = $notification->toMobilyWs($notifiable, new MobilyWsMessage());
         $number = $notifiable->routeNotificationFor('MobilyWs') ?: $notifiable->phone_number;
         // TODO Validate Number
 

--- a/src/MobilyWsChannel.php
+++ b/src/MobilyWsChannel.php
@@ -69,7 +69,7 @@ class MobilyWsChannel
     private function dispatchRequest($message, $number)
     {
         if (is_string($message)) {
-            $response = $this->api->send([
+            $response = $this->api->sendString([
                 'msg' => $message,
                 'numbers' => $number,
             ]);

--- a/src/MobilyWsChannel.php
+++ b/src/MobilyWsChannel.php
@@ -74,10 +74,7 @@ class MobilyWsChannel
                 'numbers' => $number,
             ]);
         } elseif ($message instanceof MobilyWsMessage) {
-            $response = $this->api->sendMessage([
-                'msg' => $message,
-                'numbers' => $number,
-            ]);
+            $response = $this->api->sendMessage($message, $number);
         } else {
             $errorMessage = sprintf('toMobilyWs must return a string or instance of %s. Instance of %s returned',
                 MobilyWsMessage::class,

--- a/src/MobilyWsChannel.php
+++ b/src/MobilyWsChannel.php
@@ -55,7 +55,7 @@ class MobilyWsChannel
                 'numbers' => $number,
             ]);
         } else {
-            $errorMessage = sprintf("toMobilyWs must return a string or instance of %s. Instance of %s returned %s",
+            $errorMessage = sprintf("toMobilyWs must return a string or instance of %s. Instance of %s returned",
                 MobilyWsMessage::class,
                     gettype($message)
                 );

--- a/src/MobilyWsMessage.php
+++ b/src/MobilyWsMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NotificationChannels\MobilyWs;
+
+class MobilyWsMessage
+{
+    /** @var string */
+    public $msg;
+
+    /**
+     * Create new instance of mobilyWsMessage.
+     *
+     * @param string $msg
+     *
+     * @return static
+     */
+    public static function create($msg = '')
+    {
+        return new static($msg);
+    }
+
+    /**
+     * MobilyWsMessage constructor.
+     *
+     * @param string $msg
+     */
+    public function __construct($msg = '')
+    {
+        $this->msg = $msg;
+    }
+
+    /**
+     * Set the Content of the SMS message.
+     *
+     * @param $msg
+     *
+     * @return $this
+     */
+    public function msg($msg)
+    {
+        $this->msg = $msg;
+
+        return $this;
+    }
+}

--- a/src/MobilyWsMessage.php
+++ b/src/MobilyWsMessage.php
@@ -52,6 +52,7 @@ class MobilyWsMessage
     }
 
     /**
+     * Set the message scheduled date and time
      * @param DateTime|Carbon|int $time
      *
      * @return $this
@@ -74,5 +75,24 @@ class MobilyWsMessage
         throw CouldNotSendNotification::withErrorMessage(
             sprintf('Time must be a timestamp or an object implementing DateTimeInterface. %s is given', gettype($time))
         );
+    }
+    
+    /**
+     * Get the message schedule date
+     *
+     * @return string
+     */
+    public function dateSend()
+    {
+        return $this->time->format("m/d/Y");
+    }
+    
+    /**
+     * Get the message schedule time
+     * @return string
+     */
+    public function timeSend()
+    {
+        return $this->time->format("H:i:s");
     }
 }

--- a/src/MobilyWsMessage.php
+++ b/src/MobilyWsMessage.php
@@ -2,10 +2,18 @@
 
 namespace NotificationChannels\MobilyWs;
 
+use Carbon\Carbon;
+use DateTime;
+use DateTimeInterface;
+use NotificationChannels\MobilyWs\Exceptions\CouldNotSendNotification;
+
 class MobilyWsMessage
 {
     /** @var string */
     public $text;
+
+    /** @var Carbon */
+    public $time;
 
     /**
      * Create new instance of mobilyWsMessage.
@@ -41,5 +49,30 @@ class MobilyWsMessage
         $this->text = $text;
 
         return $this;
+    }
+
+    /**
+     * @param DateTime|Carbon|int $time
+     *
+     * @return $this
+     *
+     * @throws CouldNotSendNotification
+     */
+    public function time($time)
+    {
+        if ($time instanceof DateTimeInterface) {
+            return $this->time($time->getTimestamp());
+        }
+
+        if (is_numeric($time)) {
+
+            $this->time = Carbon::createFromTimestamp($time);
+
+            return $this;
+        }
+
+        throw CouldNotSendNotification::withErrorMessage(
+            sprintf('Time must be a timestamp or an object implementing DateTimeInterface. %s is given', gettype($time))
+        );
     }
 }

--- a/src/MobilyWsMessage.php
+++ b/src/MobilyWsMessage.php
@@ -5,40 +5,40 @@ namespace NotificationChannels\MobilyWs;
 class MobilyWsMessage
 {
     /** @var string */
-    public $msg;
+    public $text;
 
     /**
      * Create new instance of mobilyWsMessage.
      *
-     * @param string $msg
+     * @param string $text
      *
      * @return static
      */
-    public static function create($msg = '')
+    public static function create($text = '')
     {
-        return new static($msg);
+        return new static($text);
     }
 
     /**
      * MobilyWsMessage constructor.
      *
-     * @param string $msg
+     * @param string $text
      */
-    public function __construct($msg = '')
+    public function __construct($text = '')
     {
-        $this->msg = $msg;
+        $this->text = $text;
     }
 
     /**
      * Set the Content of the SMS message.
      *
-     * @param $msg
+     * @param $text
      *
      * @return $this
      */
-    public function msg($msg)
+    public function text($text)
     {
-        $this->msg = $msg;
+        $this->text = $text;
 
         return $this;
     }

--- a/src/MobilyWsMessage.php
+++ b/src/MobilyWsMessage.php
@@ -52,7 +52,8 @@ class MobilyWsMessage
     }
 
     /**
-     * Set the message scheduled date and time
+     * Set the message scheduled date and time.
+     *
      * @param DateTime|Carbon|int $time
      *
      * @return $this
@@ -66,7 +67,6 @@ class MobilyWsMessage
         }
 
         if (is_numeric($time)) {
-
             $this->time = Carbon::createFromTimestamp($time);
 
             return $this;
@@ -76,23 +76,28 @@ class MobilyWsMessage
             sprintf('Time must be a timestamp or an object implementing DateTimeInterface. %s is given', gettype($time))
         );
     }
-    
+
     /**
-     * Get the message schedule date
+     * Get the message schedule date.
      *
      * @return string
      */
     public function dateSend()
     {
-        return $this->time->format("m/d/Y");
+        if ($this->time) {
+            return $this->time->format('m/d/Y');
+        }
     }
-    
+
     /**
-     * Get the message schedule time
+     * Get the message schedule time.
+     *
      * @return string
      */
     public function timeSend()
     {
-        return $this->time->format("H:i:s");
+        if ($this->time) {
+            return $this->time->format('H:i:s');
+        }
     }
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -106,7 +106,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $params = [
             'applicationType' => '68',
             'lang'            => '3',
-            'msg'             => $message->msg,
+            'msg'             => $message->text,
             'numbers'         => $number = '966550000000',
         ];
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -12,6 +12,7 @@ use function GuzzleHttp\Psr7\parse_query;
 use NotificationChannels\MobilyWs\MobilyWsApi;
 use NotificationChannels\MobilyWs\MobilyWsConfig;
 use NotificationChannels\MobilyWs\Exceptions\CouldNotSendNotification;
+use NotificationChannels\MobilyWs\MobilyWsMessage;
 
 class ApiTest extends \PHPUnit_Framework_TestCase
 {
@@ -73,6 +74,43 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         ];
 
         $api->sendString($params);
+
+        /** @var Request $request */
+        $request = $container[0]['request'];
+
+        $this->assertCount(1, $container);
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('/api/msgSend.php', $request->getRequestTarget());
+        $this->assertArraySubset($params, parse_query($request->getBody()->getContents()));
+    }
+    
+    /** @test */
+    public function it_send_request_with_correct_params_when_given_MobilyWsMessage_instance()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $mock = new MockHandler([
+            new Response(200, [], 1),
+        ]);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $options = [
+            'base_uri' => 'http://mobily.ws/api/',
+            'handler' => $stack,
+        ];
+        $client = new Client($options);
+        $mobileWsConfig = new MobilyWsConfig($this->getConfigs());
+        $api = new MobilyWsApi($mobileWsConfig, $client);
+        
+        $message = new MobilyWsMessage('SMS Text Message');
+        $params = [
+            'applicationType' => '68',
+            'lang'            => '3',
+            'msg'             => $message->msg,
+            'numbers'         => $number = '966550000000',
+        ];
+
+        $api->sendMessage($message, $number);
 
         /** @var Request $request */
         $request = $container[0]['request'];

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -49,7 +49,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_send_request_with_correct_params()
+    public function it_send_request_with_correct_params_when_given_string_message()
     {
         $container = [];
         $history = Middleware::history($container);
@@ -72,7 +72,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             'numbers'         => '966550000000',
         ];
 
-        $api->send($params);
+        $api->sendString($params);
 
         /** @var Request $request */
         $request = $container[0]['request'];

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -40,7 +40,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_can_send_a_notification_with_text()
+    public function it_can_send_a_notification_with_string_text()
     {
         $notificationWithText = new TestNotification('Text message as a string');
         $params = [
@@ -48,7 +48,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
           'numbers' => '966550000000',
         ];
 
-        $this->api->shouldReceive('send')->with($params)->andReturn(['code' => 1, 'message' => 'تمت عملية الإرسال بنجاح']);
+        $this->api->shouldReceive('sendString')->with($params)->andReturn(['code' => 1, 'message' => 'تمت عملية الإرسال بنجاح']);
 
         $response = $this->channel->send($this->notifiable, $notificationWithText);
         $this->assertEquals('تمت عملية الإرسال بنجاح', $response);
@@ -102,7 +102,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
             'msg' => 'Text message',
             'numbers' => '966550000000',
         ];
-        $this->api->shouldReceive('send')->with($params)->andReturn(['code' => 5, 'message' => 'كلمة المرور الخاصة بالحساب غير صحيحة']);
+        $this->api->shouldReceive('sendString')->with($params)->andReturn(['code' => 5, 'message' => 'كلمة المرور الخاصة بالحساب غير صحيحة']);
 
         try {
             $this->channel->send($this->notifiable, new TestNotification('Text message'));
@@ -118,7 +118,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
             'msg' => 'Text message',
             'numbers' => '966550000000',
         ];
-        $this->api->shouldReceive('send')->with($params)->andReturn(['code' => 3, 'message' => 'رصيدك غير كافي لإتمام عملية الإرسال']);
+        $this->api->shouldReceive('sendString')->with($params)->andReturn(['code' => 3, 'message' => 'رصيدك غير كافي لإتمام عملية الإرسال']);
 
         try {
             $this->channel->send($this->notifiable, new TestNotification('Text message'));

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -70,6 +70,29 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('تمت عملية الإرسال بنجاح', $response);
     }
 
+    /** @test */
+    public function it_throw_an_exception_when_given_a_message_other_than_string_or_message_instance()
+    {
+        $notificationWithArray = new TestNotification($array = ['text message from array']);
+        $params = [
+            'msg' => $array,
+            'numbers' => '966550000000',
+        ];
+
+        try {
+            $this->channel->send($this->notifiable, $notificationWithArray);
+        } catch (CouldNotSendNotification $e) {
+            $this->assertContains(
+                'toMobilyWs must return a string or instance of NotificationChannels\MobilyWs\MobilyWsMessage. Instance of array returned',
+                $e->getMessage()
+            );
+
+            return;
+        }
+
+        $this->fail('CouldNotSendNotification exception was not raised');
+    }
+
     /** @test
      * @expectedException \NotificationChannels\MobilyWs\Exceptions\CouldNotSendNotification;
      */
@@ -82,7 +105,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
         $this->api->shouldReceive('send')->with($params)->andReturn(['code' => 5, 'message' => 'كلمة المرور الخاصة بالحساب غير صحيحة']);
 
         try {
-            $this->channel->send($this->notifiable, new TestNotification("Text message"));
+            $this->channel->send($this->notifiable, new TestNotification('Text message'));
         } catch (CouldNotSendNotification $e) {
             $this->events->shouldHaveReceived('fire');
         }
@@ -98,7 +121,7 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
         $this->api->shouldReceive('send')->with($params)->andReturn(['code' => 3, 'message' => 'رصيدك غير كافي لإتمام عملية الإرسال']);
 
         try {
-            $this->channel->send($this->notifiable, new TestNotification("Text message"));
+            $this->channel->send($this->notifiable, new TestNotification('Text message'));
         } catch (CouldNotSendNotification $e) {
             $this->assertContains('رصيدك غير كافي لإتمام عملية الإرسال', $e->getMessage());
 

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -142,6 +142,19 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
 
         $this->fail('CouldNotSendNotification exception was not raised');
     }
+    
+    /** @test */
+    public function it_passes_an_instance_of_MobilyWsMessage_when_calling_toMobilyWs_method()
+    {
+        $notification = Mockery::mock(TestNotification::class);
+
+        $notification->shouldReceive('toMobilyWs')
+            ->with($this->notifiable, Mockery::type(MobilyWsMessage::class))
+            ->andReturn(new MobilyWsMessage());
+        $this->api->shouldReceive('sendMessage')->andReturn(['code' => 1, 'message' => 'ok']);
+        
+        $this->channel->send($this->notifiable, $notification);
+    }
 }
 
 class TestNotifiable

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -59,13 +59,11 @@ class ChannelTest extends \PHPUnit_Framework_TestCase
     {
         $messageInstance = new MobilyWsMessage('Text from message instance');
         $notificationWithMessageInstance = new TestNotification($messageInstance);
-        $params = [
-          'msg' => $messageInstance,
-          'numbers' => '966550000000',
-        ];
 
-        $this->api->shouldReceive('sendMessage')->with($params)->andReturn(['code' => 1, 'message' => 'تمت عملية الإرسال بنجاح']);
-
+        $this->api->shouldReceive('sendMessage')
+            ->with($messageInstance, $this->notifiable->mobile_number)
+            ->andReturn(['code' => 1, 'message' => 'تمت عملية الإرسال بنجاح']);
+        
         $response = $this->channel->send($this->notifiable, $notificationWithMessageInstance);
         $this->assertEquals('تمت عملية الإرسال بنجاح', $response);
     }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -114,4 +114,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedTime, $message->timeSend());
     }
     
+    /** @test */
+    public function it_return_null_when_there_time_is_not_set()
+    {
+        $message = new MobilyWsMessage();
+        
+        $this->assertNull($message->dateSend());
+        $this->assertNull($message->timeSend());
+    }
+    
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\MobilyWs\Test;
 
+use Carbon\Carbon;
+use NotificationChannels\MobilyWs\Exceptions\CouldNotSendNotification;
 use NotificationChannels\MobilyWs\MobilyWsMessage;
 
 class MessageTest extends \PHPUnit_Framework_TestCase
@@ -40,6 +42,62 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message = MobilyWsMessage::create('Message content is here');
         
         $this->assertEquals('Message content is here', $message->text);
+    }
+    
+    /** @test */
+    public function it_can_set_delay_from_Carbon_instance()
+    {
+        $carbon = Carbon::parse('+ 1 week');
+        $message = MobilyWsMessage::create('Message content is here');
+        $message->time($carbon);
+        
+        $this->assertEquals($carbon, $message->time);
+        $this->assertInstanceOf(Carbon::class, $message->time);
+    }
+    
+    /** @test */
+    public function it_can_set_delay_from_DateTime_instance()
+    {
+        $carbon = Carbon::parse('+ 1 week');
+        $dt = new \DateTime($carbon->toDateTimeString());
+        $this->assertEquals($dt, $carbon);
+        
+        $message = MobilyWsMessage::create('Message content is here');
+        $message->time($dt);
+
+        $this->assertEquals($carbon, $message->time);
+        $this->assertInstanceOf(Carbon::class, $message->time);
+    }
+    
+    /** @test */
+    public function it_can_set_delay_from_timestamp()
+    {
+        $carbon = Carbon::parse('+ 1 week');
+        
+        $message = MobilyWsMessage::create('Message content is here');
+        $message->time($carbon->timestamp);
+
+        $this->assertEquals($carbon, $message->time);
+        $this->assertInstanceOf(Carbon::class, $message->time);
+    }
+    
+    /** @test */
+    public function it_throw_an_exception_when_given_invalid_time()
+    {
+        $message = MobilyWsMessage::create('Message content is here');
+        
+        try {
+            $message->time(['invalid time format']);
+        } catch (CouldNotSendNotification $exception) {
+            $this->assertContains(
+                "Time must be a timestamp or an object implementing DateTimeInterface. array is given",
+                $exception->getMessage()
+            );
+            
+            return;
+        }
+        
+        $this->fail('An exception should be thrown when invalid time format is given');
     }
     
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -22,16 +22,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message = new MobilyWsMessage('Message content is here');
         
         $this->assertInstanceOf(MobilyWsMessage::class, $message);
-        $this->assertEquals('Message content is here', $message->msg);
+        $this->assertEquals('Message content is here', $message->text);
     }
     
     /** @test */
     public function it_can_set_content()
     {
         $message = new MobilyWsMessage();
-        $message->msg('Message content is here');
+        $message->text('Message content is here');
         
-        $this->assertEquals('Message content is here', $message->msg);
+        $this->assertEquals('Message content is here', $message->text);
     }
     
     /** @test */
@@ -39,7 +39,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = MobilyWsMessage::create('Message content is here');
         
-        $this->assertEquals('Message content is here', $message->msg);
+        $this->assertEquals('Message content is here', $message->text);
     }
     
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -100,4 +100,18 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->fail('An exception should be thrown when invalid time format is given');
     }
     
+    /** @test */
+    public function it_return_date_and_time_in_a_proper_mobily_ws_required_format()
+    {
+        $expectedDate = "08/15/2017";
+        $expectedTime = "23:15:30";
+        $carbon = Carbon::parse('08/15/2017 23:15:30');
+        
+        $message = new MobilyWsMessage();
+        $message->time($carbon);
+        
+        $this->assertEquals($expectedDate, $message->dateSend());
+        $this->assertEquals($expectedTime, $message->timeSend());
+    }
+    
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NotificationChannels\MobilyWs\Test;
+
+use NotificationChannels\MobilyWs\MobilyWsMessage;
+
+class MessageTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+    
+    /** @test */
+    public function it_can_set_message_content_when_constructing()
+    {
+        $message = new MobilyWsMessage('Message content is here');
+        
+        $this->assertInstanceOf(MobilyWsMessage::class, $message);
+        $this->assertEquals('Message content is here', $message->msg);
+    }
+    
+    /** @test */
+    public function it_can_set_content()
+    {
+        $message = new MobilyWsMessage();
+        $message->msg('Message content is here');
+        
+        $this->assertEquals('Message content is here', $message->msg);
+    }
+    
+    /** @test */
+    public function it_can_create_new_message()
+    {
+        $message = MobilyWsMessage::create('Message content is here');
+        
+        $this->assertEquals('Message content is here', $message->msg);
+    }
+    
+}


### PR DESCRIPTION
The `MobilyWsMessage` class is a message builder which will be passed to the `toMobilyWs` method in which the user can add the message content and some options. 

Currently, the only available method is `text` which just set the content of the SMS. It is the same as returning string from `toMobilyWs`.
